### PR TITLE
Changes to enable building on Mac OS X

### DIFF
--- a/source/reader.c
+++ b/source/reader.c
@@ -4,6 +4,7 @@
 
 #include <libxml/parser.h>
 #include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
 
 #include "array.h"
 #include "document.h"
@@ -446,8 +447,8 @@ void readDocument(Document* destination, char* filename) {
 		
 	// create XPath context
 	CONTEXT = xmlXPathNewContext(DOCUMENT);
-	xmlXPathRegisterNs(CONTEXT, NSPREFIX_SBOL, NSURL_SBOL);
-	xmlXPathRegisterNs(CONTEXT, NSPREFIX_RDF, NSURL_RDF);
+	xmlXPathRegisterNs(CONTEXT, (const xmlChar*)NSPREFIX_SBOL, (const xmlChar*)NSURL_SBOL);
+	xmlXPathRegisterNs(CONTEXT, (const xmlChar*)NSPREFIX_RDF, (const xmlChar*)NSURL_RDF);
 
 	#define GLOBAL_XPATH BAD_CAST "//" NSPREFIX_SBOL ":"
 

--- a/source/sequenceannotation.c
+++ b/source/sequenceannotation.c
@@ -7,6 +7,7 @@
 #include "object.h"
 #include "document.h"
 #include "dnacomponent.h"
+#include "dnasequence.h"
 #include "sequenceannotation.h"
 #include "utilities.h"
 

--- a/source/sequenceannotation.c
+++ b/source/sequenceannotation.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 
 #include "property.h"
 #include "array.h"

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -23,7 +23,7 @@ IF( SWIG_FOUND )
 	# in writing a higher-level wrapper, and because Python
 	# will try to import them anyway and fail
 	ADD_LIBRARY( sbol_swig
-		SHARED
+		STATIC
 		${SBOL_SOURCE_FILES}
 	)
 	TARGET_LINK_LIBRARIES( sbol_swig

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -48,15 +48,21 @@ IF( SWIG_FOUND )
         libsbol.i
         ${SBOL_SOURCE_FILES}
     )
-    SWIG_LINK_LIBRARIES( libsbol
-        ${PYTHON_LIBRARIES}
-        xml2
-        sbol_swig
-    )
-
     IF(APPLE)
+      # Do not link in the Python libraries
+      SWIG_LINK_LIBRARIES( libsbol
+          xml2
+          sbol_swig
+      )
+
       # Resolve Pyhton symbols dynamically due to differing runtime env
       SET_TARGET_PROPERTIES(_libsbol PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    ELSE()
+      SWIG_LINK_LIBRARIES( libsbol
+          ${PYTHON_LIBRARIES}
+          xml2
+          sbol_swig
+      )
     ENDIF()
 
     INSTALL(TARGETS _libsbol DESTINATION lib)

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -54,6 +54,11 @@ IF( SWIG_FOUND )
         sbol_swig
     )
 
+    IF(APPLE)
+      # Resolve Pyhton symbols dynamically due to differing runtime env
+      SET_TARGET_PROPERTIES(_libsbol PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    ENDIF()
+
     INSTALL(TARGETS _libsbol DESTINATION lib)
 
 ELSE()

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-FIND_PACKAGE( SWIG )
+FIND_PACKAGE( SWIG REQUIRED )
 IF( SWIG_FOUND )
 
 	# adjust paths
@@ -29,11 +29,16 @@ IF( SWIG_FOUND )
 	TARGET_LINK_LIBRARIES( sbol_swig
 		xml2
 	)
+
+  INSTALL(TARGETS sbol_swig DESTINATION lib)
 	
 	# set up some SWIG stuff
     INCLUDE( ${SWIG_USE_FILE} )
-    FIND_PACKAGE( PythonLibs )
-    INCLUDE_DIRECTORIES( ${PYTHON_INCLUDE_PATH} )
+    FIND_PACKAGE( PythonLibs REQUIRED )
+    IF(NOT PYTHONLIBS_FOUND)
+      MESSAGE( "Python libraries not found; unable to generate Python bindings" )
+    ENDIF()
+    INCLUDE_DIRECTORIES( ${PYTHON_INCLUDE_DIRS} )
     SET( CMAKE_SWIG_FLAGS "" )
     SET( CMAKE_SWIG_OUTDIR ${SBOL_RELEASE_DIR} )
 
@@ -48,6 +53,8 @@ IF( SWIG_FOUND )
         xml2
         sbol_swig
     )
+
+    INSTALL(TARGETS _libsbol DESTINATION lib)
 
 ELSE()
 


### PR DESCRIPTION
Hey Bryan,
Here are my changes for Mac. They include
* Removing <malloc.h> since it does not exist on Mac (including stdlib.h should be sufficient on all platforms)
* Include missing header libxml/xpathInternals.h
* Resolve Python symbols dynamically on Mac (trick from Andy - the code needs to be usable from different Python interpreters)
* sbol_swig must be static for Tellurium
* Explicit casts to `const xmlChar*` to silence warnings

I don't think these changes will cause you problems on Windows but let me know if they do.