### PR TITLE
Added fix to SequenceAnnotation to allow reverse strands to be set.

### DIFF
--- a/source/sequenceannotation.c
+++ b/source/sequenceannotation.c
@@ -84,7 +84,7 @@ void setSequenceAnnotationEnd(SequenceAnnotation* ann, int end) {
 
 // TODO use PolarityProperty
 void setSequenceAnnotationStrand(SequenceAnnotation* ann, int polarity) {
-	if (!ann || polarity < -1 || polarity > 1)
+	if (!ann || polarity < STRAND_FORWARD || polarity > STRAND_REVERSE)
 		return;
 	setPolarityProperty(ann->strand, polarity);
 }


### PR DESCRIPTION
Hi Bryan,

An additional fix to allow SequenceAnnotation strands to be set to reverse. Previously, this wasn't possible. (The code rejected strands of 2, which corresponds to reverse).

Cheers,

Neil.
